### PR TITLE
Bugfix/duplicate resources in cart

### DIFF
--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -35,7 +35,7 @@ class Cart(ViewSet):
             open_order.save()
 
         line_item = OrderProduct()
-        line_item.product = Product.objects.get(pk=request.data["product_id"])
+        line_item.product = Product.objects.get(pk=request.data.get('product_id'))
         line_item.order = open_order
         line_item.save()
 

--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -114,22 +114,15 @@ class Cart(ViewSet):
             open_order = Order.objects.get(
                 customer=current_user, payment_type=None)
 
-            products_on_order = Product.objects.filter(
-                lineitems__order=open_order)
 
             serialized_order = OrderSerializer(
                 open_order, many=False, context={'request': request})
 
-            product_list = ProductSerializer(
-                products_on_order, many=True, context={'request': request})
 
-            final = {
-                "order": serialized_order.data
-            }
-            final["order"]["products"] = product_list.data
-            final["order"]["size"] = len(products_on_order)
+            final = serialized_order.data
+            final["size"] = len(final["lineitems"])
 
         except Order.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
-        return Response(final["order"])
+        return Response(final)

--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -87,3 +87,4 @@ class LineItems(ViewSet):
 
         except Exception as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- removed redundant serializers in cart.py view

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET /cart 

200OK

{
    "id": 9,
    "url": "http://localhost:8000/orders/9",
    "created_date": "2018-12-08",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/6",
    "lineitems": [
        {
            "id": 13,
            "product": {
                "id": 51,
                "name": "Optima",
                "price": 1655.15,
                "number_sold": 0,
                "description": "2008 Kia",
                "quantity": 3,
                "created_date": "2019-05-21",
                "location": "London",
                "image_path": "http://localhost:8000/media/products/vehicle.png",
                "average_rating": 0
            }
        },
        {
            "id": 14,
            "product": {
                "id": 5,
                "name": "Optima",
                "price": 1655.15,
                "number_sold": 0,
                "description": "2008 Kia",
                "quantity": 3,
                "created_date": "2019-05-21",
                "location": "Seoul",
                "image_path": "http://localhost:8000/media/products/vehicle.png",
                "average_rating": 0
            }
        }
    ],
    "size": 2
}

## Testing

Description of how to test code...

- [ ] run GET /cart in POSTMAN


## Related Issues

- Fixes #36 