### PR TITLE
expiration and create dates were swapped in paymenttype view

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- in the create function in the paymenttype view, the values of expiration date and create date were swapped

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET /paymenttypes

  {
        "id": 7,
        "url": "http://localhost:8000/paymenttypes/7",
        "merchant_name": "VISA",
        "account_number": "902475163948571",
        "expiration_date": "2028-10-03",
        "create_date": "2024-10-03"
    }

## Testing

Description of how to test code...

- [ ] Create a new payment
- [ ] run GET /paymenttypes in Postman, and ensure dates are corrent


## Related Issues

- Fixes #30