### PR TITLE
delete payment test added

### DIFF
--- a/tests/payments.py
+++ b/tests/payments.py
@@ -41,3 +41,16 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
     # TODO: Delete payment type
+    def test_delete_payment_type(self):
+        
+        #add payment type
+        self.test_create_payment_type()
+        
+        #remove payment type
+        url = "/paymenttypes/1"
+        self.client.credentials(HTTP_AUTHORIZATION = 'Token ' + self.token)
+        
+        response = self.client.delete(url, format='json')
+        
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+      


### PR DESCRIPTION
Description of PR that completes issue here...
Created a test case for the deletion of a payment type

- I added a test case that ensures the deletion of a payment type is completed

## Testing

Description of how to test code...
To test the code, could you get my branch into your local machine, once that is done, run the debugger on the API? next, run python3 manage.py test tests -v 1 on the terminal to run the tests 

